### PR TITLE
explorer: Show event name / date on every page.

### DIFF
--- a/lib/conecerto_scoreboard_web/components/layouts.ex
+++ b/lib/conecerto_scoreboard_web/components/layouts.ex
@@ -67,7 +67,7 @@ defmodule Conecerto.ScoreboardWeb.Layouts do
     ~H"""
     <div class="mt-4">
       <div class="text-xl text-center font-semibold pb-2">Sponsored By</div>
-      <div class="flex flex-wrap justify-around bg-white my-2 p-2 gap-2">
+      <div class="flex flex-wrap justify-around bg-white p-2 gap-2">
         <%= for sponsor <- @sponsors do %>
           <a href={sponsor.url} target="_blank" class="flex">
             <img src={brand_path(@conn, sponsor)} class="h-[4rem] object-contain shrink-1" />
@@ -78,11 +78,11 @@ defmodule Conecerto.ScoreboardWeb.Layouts do
     """
   end
 
-  def title_suffix(nil = _event_name),
-    do: " · Conecerto Scoreboard"
+  def title_suffix(event_date, nil = _event_name),
+    do: " · #{event_date} · Conecerto Scoreboard"
 
-  def title_suffix(event_name),
-    do: "· #{event_name} · Conecerto Scoreboard"
+  def title_suffix(event_date, event_name),
+    do: " · #{event_name} · #{event_date} · Conecerto Scoreboard"
 
   defp brand_path(conn, brand),
     do: with_base_path(conn, @endpoint.path(brand.path))

--- a/lib/conecerto_scoreboard_web/components/layouts/explorer.html.heex
+++ b/lib/conecerto_scoreboard_web/components/layouts/explorer.html.heex
@@ -15,6 +15,14 @@
     <.flash_group flash={@flash} />
     <div class="flex justify-center">
       <div class="basis-md">
+        <div class="mt-4 mb-4">
+          <%= if @event_name do %>
+            <div class="text-2xl text-center font-semibold">{@event_name}</div>
+            <div class="text-md text-center">{@event_date}</div>
+          <% else %>
+            <div class="text-2xl text-center font-semibold">{@event_date}</div>
+          <% end %>
+        </div>
         {@inner_content}
         <.sponsor_logos conn={@conn} sponsors={@sponsors} />
         <div class="p-1 mt-4 mb-3">

--- a/lib/conecerto_scoreboard_web/components/layouts/root.html.heex
+++ b/lib/conecerto_scoreboard_web/components/layouts/root.html.heex
@@ -7,7 +7,7 @@
     <meta name="theme-color" content={top_nav_fill_color} />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <.live_title suffix={title_suffix(assigns[:event_name])}>
+    <.live_title suffix={title_suffix(assigns[:event_date], assigns[:event_name])}>
       {assigns[:page_title] || assigns[:active_tab] || "Home"}
     </.live_title>
     <link phx-track-static rel="stylesheet" href={with_base_path(@conn, ~p"/assets/app.css")} />

--- a/lib/conecerto_scoreboard_web/controllers/explorer_controller.ex
+++ b/lib/conecerto_scoreboard_web/controllers/explorer_controller.ex
@@ -81,7 +81,8 @@ defmodule Conecerto.ScoreboardWeb.ExplorerController do
     [
       root_font_size: @root_font_size,
       colors: Conecerto.Scoreboard.config(:explorer_colors),
-      event_name: Scoreboard.config(:event_name) || format_date(Scoreboard.config(:event_date)),
+      event_date: format_date(Scoreboard.config(:event_date)),
+      event_name: Scoreboard.config(:event_name),
       last_updated_at: Scoreboard.last_updated_at(),
       organizer: Brands.get_organizer(),
       sponsors: Brands.get_sponsors()
@@ -89,6 +90,12 @@ defmodule Conecerto.ScoreboardWeb.ExplorerController do
     |> Keyword.merge(extra)
   end
 
-  defp format_date(date),
-    do: String.replace(date, "_", "/")
+  defp format_date(date) do
+    date
+    |> String.split("_")
+    |> Enum.map(&String.to_integer(&1, 10))
+    |> List.to_tuple()
+    |> Date.from_erl!()
+    |> Calendar.strftime("%b %d, %Y")
+  end
 end

--- a/lib/conecerto_scoreboard_web/controllers/explorer_html/groups.html.heex
+++ b/lib/conecerto_scoreboard_web/controllers/explorer_html/groups.html.heex
@@ -1,10 +1,12 @@
-<%= for group <- @groups do %>
-  <div class="p-1">
-    <div class="text-xl text-center font-semibold pb-2 pt-1">{group.name}</div>
-    <Conecerto.ScoreboardWeb.Tables.group_scores
-      scores={group.scores}
-      time_column_title="PAX Best"
-      time_column_field={:pax_time}
-    />
-  </div>
-<% end %>
+<div class="flex flex-col gap-4">
+  <%= for group <- @groups do %>
+    <div class="px-1">
+      <div class="text-xl text-center font-semibold pb-2">{group.name}</div>
+      <Conecerto.ScoreboardWeb.Tables.group_scores
+        scores={group.scores}
+        time_column_title="PAX Best"
+        time_column_field={:pax_time}
+      />
+    </div>
+  <% end %>
+</div>

--- a/lib/conecerto_scoreboard_web/controllers/explorer_html/home.html.heex
+++ b/lib/conecerto_scoreboard_web/controllers/explorer_html/home.html.heex
@@ -1,14 +1,7 @@
-<%= if @event_name do %>
-  <div class="mt-4">
-    <div class="text-2xl text-center font-semibold">{@event_name}</div>
-  </div>
-<% end %>
-<%= if @radio_frequency do %>
-  <div class="text-xl text-center p-1 mt-4">
-    Live commentary on <span class="font-semibold">{@radio_frequency}</span>
-  </div>
-<% end %>
-<div class="p-1 mt-4">
+<div :if={@radio_frequency} class="text-xl text-center mt-4">
+  Live commentary on <span class="font-semibold">{@radio_frequency}</span>
+</div>
+<div class="mt-4">
   <div class="text-xl text-center font-semibold pb-2">Most Recent Runs</div>
   <Conecerto.ScoreboardWeb.Tables.recent_runs runs={@recent_runs} />
 </div>


### PR DESCRIPTION
This makes it clear what event is the user browsing regadless of what page they are on. Given how scoreboard is now also used to publish final results for multiple events, this kind of information/visibility becomes more important.

Considering usual mobile device screen sizes, the vertical space taken up by this data is relatively small and so the new layout works for live result browsing as well.